### PR TITLE
🔧 Fix: Agregar import faltante de settings

### DIFF
--- a/src/application/services/file_processing_service.py
+++ b/src/application/services/file_processing_service.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import io
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 from pathvalidate import sanitize_filename
 
 from pypdf import PdfReader
 
 from src.domain.models.file_models import FileStatus, FileDocument
+from src.adapters.config.settings import settings
 
 if TYPE_CHECKING:
     from src.domain.ports.file_repository_port import FileRepositoryPort


### PR DESCRIPTION
## 🐛 **Problema**

El archivo `file_processing_service.py` usa `settings.file_chapter_max_pages` en la línea 70 pero **no importa** el módulo `settings`.

**Error:**
```python
NameError: name 'settings' is not defined
```

## ✅ **Solución**

Agregado el import faltante:
```python
from src.adapters.config.settings import settings
```

También agregado `Optional` al import de `typing` para el tipo de retorno de `get_file_status()`.

## 🧪 **Testing**

- [x] El código compila sin errores
- [x] La indexación de PDFs ahora funciona correctamente
- [x] No se rompe ninguna funcionalidad existente

## 📝 **Archivos modificados**

- `src/application/services/file_processing_service.py`

## 🎯 **Impacto**

- **Crítico**: Sin este fix, la indexación de PDFs falla completamente
- **Alcance**: Solo afecta al servicio de procesamiento de archivos
- **Riesgo**: Bajo (solo agrega un import faltante)

---

**Merge recomendado:** ✅ Inmediato